### PR TITLE
Fixed project building when it is located in a path with spaces.

### DIFF
--- a/Source/AtlusLibSharp/AtlusLibSharp.csproj
+++ b/Source/AtlusLibSharp/AtlusLibSharp.csproj
@@ -248,7 +248,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y $(SolutionDir)..\Dependencies\Managed\Assimp32.dll  $(ProjectDir)$(OutDir)</PostBuildEvent>
+    <PostBuildEvent>xcopy /y "$(SolutionDir)..\Dependencies\Managed\Assimp32.dll" "$(ProjectDir)$(OutDir)"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Just a small fix in order to be able to build when the project is located in a path with spaces. It was failing at the post-build event xcopy command.