### PR TITLE
Fixed some palette alpha issues with textures in PSMCT32 format.

### DIFF
--- a/Source/AmicitiaLibrary/Graphics/TMX/TMXFile.cs
+++ b/Source/AmicitiaLibrary/Graphics/TMX/TMXFile.cs
@@ -476,7 +476,7 @@ namespace AmicitiaLibrary.Graphics.TMX
                 Color[][] palettes;
 
                 if (PaletteFormat == PS2PixelFormat.PSMTC32)
-                    palettes = ScalePSMCT32PaletteToFullAlphaRange();
+                    palettes = ScalePSMCT32PaletteToFullAlphaRange(Palettes);
                 else
                     palettes = Palettes;
 
@@ -516,19 +516,20 @@ namespace AmicitiaLibrary.Graphics.TMX
             PixelIndices = temp;
         }
 
-        private Color[][] ScalePSMCT32PaletteToFullAlphaRange()
+        private static Color[][] ScalePSMCT32PaletteToFullAlphaRange(Color[][] palettes)
         {
-            Color[][] palettes = new Color[PaletteCount][];
+            int palettesCount = palettes.Length;
+            Color[][] scaledPalettes = new Color[palettesCount][];
 
-            for (int p = 0; p < PaletteCount; p++)
+            for (int p = 0; p < palettesCount; p++)
             {
-                palettes[p] = ScalePSMCT32PixelsToFullAlphaRange(Palettes[p]);
+                scaledPalettes[p] = ScalePSMCT32PixelsToFullAlphaRange(palettes[p]);
             }
 
-            return palettes;
+            return scaledPalettes;
         }
 
-        private Color[] ScalePSMCT32PixelsToFullAlphaRange(Color[] colors)
+        private static Color[] ScalePSMCT32PixelsToFullAlphaRange(Color[] colors)
         {
             int colorCount = colors.Length;
             Color[] scaledColors = new Color[colorCount];

--- a/Source/AmicitiaLibrary/Graphics/TMX/TMXFile.cs
+++ b/Source/AmicitiaLibrary/Graphics/TMX/TMXFile.cs
@@ -473,13 +473,20 @@ namespace AmicitiaLibrary.Graphics.TMX
         {
             if (UsesPalette)
             {
+                Color[][] palettes;
+
+                if (PaletteFormat == PS2PixelFormat.PSMTC32)
+                    palettes = ScalePSMCT32PaletteToFullAlphaRange();
+                else
+                    palettes = Palettes;
+
                 if (mipIdx == -1)
                 {
-                    mBitmap = BitmapHelper.Create(Palettes[palIdx], PixelIndices, Width, Height);
+                    mBitmap = BitmapHelper.Create(palettes[palIdx], PixelIndices, Width, Height);
                 }
                 else
                 {
-                    mBitmap = BitmapHelper.Create(Palettes[palIdx], MipMapPixelIndices[mipIdx],
+                    mBitmap = BitmapHelper.Create(palettes[palIdx], MipMapPixelIndices[mipIdx],
                         GetMipDimension(Width, mipIdx), GetMipDimension(Height, mipIdx));
                 }
             }
@@ -487,11 +494,13 @@ namespace AmicitiaLibrary.Graphics.TMX
             {
                 if (mipIdx == -1)
                 {
-                    mBitmap = BitmapHelper.Create(Pixels, Width, Height);
+                    Color[] pixels = PixelFormat == PS2PixelFormat.PSMTC32 ? ScalePSMCT32PixelsToFullAlphaRange(Pixels) : Pixels;
+                    mBitmap = BitmapHelper.Create(pixels, Width, Height);
                 }
                 else
                 {
-                    mBitmap = BitmapHelper.Create(MipMapPixels[mipIdx], GetMipDimension(Width, mipIdx), GetMipDimension(Height, mipIdx));
+                    Color[] pixels = PixelFormat == PS2PixelFormat.PSMTC32 ? ScalePSMCT32PixelsToFullAlphaRange(MipMapPixels[mipIdx]) : MipMapPixels[mipIdx];
+                    mBitmap = BitmapHelper.Create(pixels, GetMipDimension(Width, mipIdx), GetMipDimension(Height, mipIdx));
                 }
             }
         }
@@ -505,6 +514,35 @@ namespace AmicitiaLibrary.Graphics.TMX
             byte[] temp;
             BitmapHelper.QuantizeBitmap(bitmap, paletteColorCount, out temp, out Palettes[0]);
             PixelIndices = temp;
+        }
+
+        private Color[][] ScalePSMCT32PaletteToFullAlphaRange()
+        {
+            Color[][] palettes = new Color[PaletteCount][];
+
+            for (int p = 0; p < PaletteCount; p++)
+            {
+                palettes[p] = ScalePSMCT32PixelsToFullAlphaRange(Palettes[p]);
+            }
+
+            return palettes;
+        }
+
+        private Color[] ScalePSMCT32PixelsToFullAlphaRange(Color[] colors)
+        {
+            int colorCount = colors.Length;
+            Color[] scaledColors = new Color[colorCount];
+
+            for (int c = 0; c < colorCount; c++)
+            {
+                scaledColors[c] = Color.FromArgb(
+                    PS2PixelFormatHelper.ScaleHalfRangeAlphaToFullRange(colors[c].A),
+                    colors[c].R,
+                    colors[c].G,
+                    colors[c].B);
+            }
+
+            return scaledColors;
         }
     }
 }


### PR DESCRIPTION
Alpha values in these type of textures were incorrectly read / saved. So after every save those textures would become more and more transparent.