### PR TITLE
Continued Crossplatform support

### DIFF
--- a/Source/Amicitia/MainForm.cs
+++ b/Source/Amicitia/MainForm.cs
@@ -5,6 +5,7 @@ using System.IO;
 using Amicitia.ResourceWrappers;
 using AmicitiaLibrary.Graphics;
 using OpenTK;
+using OpenTK.Input;
 using System.Runtime.InteropServices;
 using AmicitiaLibrary.Graphics.RenderWare;
 using System.Drawing;
@@ -442,7 +443,6 @@ namespace Amicitia
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool AllocConsole();
-
         public static bool GetAsyncKey(Keys key)
         {
             if (MainForm.GLControl.Focused)

--- a/Source/Amicitia/ModelViewer/ModelViewer.cs
+++ b/Source/Amicitia/ModelViewer/ModelViewer.cs
@@ -316,13 +316,13 @@ namespace Amicitia.ModelViewer
                 inputWasHandled = true;
             }
 
-            if (state[Key.A])
+            if (state[Key.D])
             {
                 mCamera.Position -= Vector3.Cross(mCamera.Forward, new Vector3(0, 1.0f, 0)) * moveSpeed; // tp = new Vector3(tp.X, tp.Y + 10f, tp.Z);
                 inputWasHandled = true;
             }
 
-            if (state[Key.D])
+            if (state[Key.A])
             {
                 mCamera.Position += Vector3.Cross(mCamera.Forward, new Vector3(0, 1.0f, 0)) * moveSpeed; // tp = new Vector3(tp.X, tp.Y - 10f, tp.Z);
                 inputWasHandled = true;

--- a/Source/Amicitia/ModelViewer/ModelViewer.cs
+++ b/Source/Amicitia/ModelViewer/ModelViewer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 using OpenTK.Graphics;
+using OpenTK.Input;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
 using AmicitiaLibrary.Graphics.RenderWare;
@@ -291,53 +292,53 @@ namespace Amicitia.ModelViewer
             return true;
         }
 
-        private void Input(object sender, System.Windows.Forms.KeyPressEventArgs args )
+        private void Input(object sender, System.Windows.Forms.KeyPressEventArgs args)
         {
+            var state = OpenTK.Input.Keyboard.GetState();
             if (!mIsViewFocused || !mCanRender )
                 return;
-
             Vector3 oldpos = mCamera.Position;
             float moveSpeed = 10f;
-            if (NativeMethods.GetAsyncKey(Keys.Shift))
+            if (state[Key.ShiftLeft])
                 moveSpeed *= 2;
 
             bool inputWasHandled = false;
 
-            if ( NativeMethods.GetAsyncKey( Keys.W ) )
+            if (state[Key.W])
             {
-                mCamera.Position += mCamera.Forward * moveSpeed; // tp = new Vector3(tp.X, tp.Y, tp.Z + 10f);
+                    mCamera.Position += mCamera.Forward * moveSpeed; // tp = new Vector3(tp.X, tp.Y, tp.Z + 10f);
                 inputWasHandled = true;
             }
 
-            if (NativeMethods.GetAsyncKey(Keys.S))
+            if (state[Key.S])
             {
                 mCamera.Position -= mCamera.Forward * moveSpeed; // tp = new Vector3(tp.X, tp.Y, tp.Z - 10f);
                 inputWasHandled = true;
             }
 
-            if (NativeMethods.GetAsyncKey(Keys.D))
+            if (state[Key.A])
             {
                 mCamera.Position -= Vector3.Cross(mCamera.Forward, new Vector3(0, 1.0f, 0)) * moveSpeed; // tp = new Vector3(tp.X, tp.Y + 10f, tp.Z);
                 inputWasHandled = true;
             }
 
-            if (NativeMethods.GetAsyncKey(Keys.A))
+            if (state[Key.D])
             {
                 mCamera.Position += Vector3.Cross(mCamera.Forward, new Vector3(0, 1.0f, 0)) * moveSpeed; // tp = new Vector3(tp.X, tp.Y - 10f, tp.Z);
                 inputWasHandled = true;
             }
 
-            if (NativeMethods.GetAsyncKey(Keys.Q))
-            {
-                mCamera.Position += new Vector3(0, 1.0f, 0) * moveSpeed; // tp = new Vector3(tp.X, tp.Y - 10f, tp.Z);
-                inputWasHandled = true;
-            }
+          	if (state[Key.Q])
+          	{
+              mCamera.Position += new Vector3(0, 1.0f, 0) * moveSpeed; // tp = new Vector3(tp.X, tp.Y - 10f, tp.Z);
+              inputWasHandled = true;
+          	}
 
-            if (NativeMethods.GetAsyncKey(Keys.E))
-            {
-                mCamera.Position -= new Vector3(0, 1.0f, 0) * moveSpeed; // tp = new Vector3(tp.X, tp.Y - 10f, tp.Z);
-                inputWasHandled = true;
-            }
+          	if (state[Key.E])
+          	{
+              mCamera.Position -= new Vector3(0, 1.0f, 0) * moveSpeed; // tp = new Vector3(tp.X, tp.Y - 10f, tp.Z);
+              inputWasHandled = true;
+          	}
 
             if ( inputWasHandled && IsNaN( mCamera.Position))
             {

--- a/Source/Amicitia/Utilities/DialogCenteringService.cs
+++ b/Source/Amicitia/Utilities/DialogCenteringService.cs
@@ -54,7 +54,12 @@ namespace Amicitia.Utilities
 
         public void Dispose()
         {
-            UnhookWindowsHookEx(mHHook);
+            //similar to the check monyarm implemented, just disables this function so files can be opened with mono runtime.
+            Type t = Type.GetType("Mono.Runtime");
+            if (t == null)
+            {
+                UnhookWindowsHookEx(mHHook);
+            }
         }
 
         private void CenterWindow(IntPtr hChildWnd)

--- a/Source/AmicitiaLibrary/AmicitiaLibrary.csproj
+++ b/Source/AmicitiaLibrary/AmicitiaLibrary.csproj
@@ -258,7 +258,7 @@ xcopy /y "$(SolutionDir)..\Dependencies\Managed\Assimp64.dll" "$(ProjectDir)$(Ou
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\..\Users\smart\Documents\Visual Studio 2017\Projects\dump_rmd\packages\AssimpNet.4.1.0\build\AssimpNet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\Users\smart\Documents\Visual Studio 2017\Projects\dump_rmd\packages\AssimpNet.4.1.0\build\AssimpNet.targets'))" />
+    <!-- Don't know what this does, but it breaks the build on linux <Error Condition="!Exists('..\..\..\..\..\Users\smart\Documents\Visual Studio 2017\Projects\dump_rmd\packages\AssimpNet.4.1.0\build\AssimpNet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\Users\smart\Documents\Visual Studio 2017\Projects\dump_rmd\packages\AssimpNet.4.1.0\build\AssimpNet.targets'))" />-->
   </Target>
   <PropertyGroup>
     <PostBuildEvent />


### PR DESCRIPTION
Disables the ErrorCondition that causes Amicitia not to compile when Assimp isn't in a specific location.
Creates an exception for the dispose method in the DialogCenteringService when running with Mono similar to the one implemented in  #11, which allows the program to load files. 
Replaced the GetAsyncKeyState Methods used for camera controls in the model viewer with a keyboard state check from OpenTK.Input, which allows the camera controls to be used without a hard crash. 