### PR TITLE
Compressed bitmap display + saving fix

### DIFF
--- a/Source/AmicitiaLibrary/Graphics/DDS/DDSCodec.cs
+++ b/Source/AmicitiaLibrary/Graphics/DDS/DDSCodec.cs
@@ -377,7 +377,7 @@ namespace AmicitiaLibrary.Graphics.DDS
             }
         }
 
-        private static MemoryStream ReadBCMipLine( Stream compressed, int mipHeight, int mipWidth, int bitsPerScanLine, long mipOffset, int compressedLineSize, int rowIndex, Func<Stream, List<byte[]>> decompressBlock )
+        private static MemoryStream ReadBCMipLine( Stream compressed, int mipWidth, int mipHeight, int bitsPerScanLine, long mipOffset, int compressedLineSize, int rowIndex, Func<Stream, List<byte[]>> decompressBlock )
         {
             var bitsPerPixel = 4;
 


### PR DESCRIPTION
Looks like there's a mix-up between `mipHeight` and `mipWidth` in `ReadBCMipLine`.

Before:

![before](https://user-images.githubusercontent.com/36057965/93913580-f54ba900-fd0d-11ea-9d96-40091f9a9b6a.png)

After:

![after](https://user-images.githubusercontent.com/36057965/93913595-f8df3000-fd0d-11ea-877d-e5c40ff9e5c9.png)
